### PR TITLE
Fix dependency on ember-new-computed

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
-    "ember-new-computed": "1.0.2",
     "ember-suave": "0.1.11",
     "ember-try": "0.0.6"
   },
@@ -43,7 +42,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.0.0",
+    "ember-new-computed": "1.0.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
By making `ember-new-computed` a dependency instead of a development dependency, `ember install` will take care of executing the same for the addon.

Fixes #2.
