### PR TITLE
More strict in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,11 @@ env:
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
-
+  - EMBER_TRY_SCENARIO=ember-beta
 matrix:
   fast_finish: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: ALLOW_DEPRECATIONS=true EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ env:
   - EMBER_TRY_SCENARIO=ember-2.1
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
-  - EMBER_TRY_SCENARIO=ember-beta
+  - ALLOW_DEPRECATIONS=true EMBER_TRY_SCENARIO=ember-canary
 matrix:
   fast_finish: true
   allow_failures:

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -34,6 +34,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'test') {
+    ENV.EmberENV.RAISE_ON_DEPRECATION = !process.env['ALLOW_DEPRECATIONS'];
     // Testem prefers this...
     ENV.baseURL = '/';
     ENV.locationType = 'none';


### PR DESCRIPTION
* Don't tolerate CI failures in ember beta channel
* Don't tolerate deprecation warnings except in canary