### PR TITLE
Fix dependency on ember-cli-version-checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^1.2.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-cli-version-checker": "^1.1.4",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
@@ -45,7 +44,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.5",
+    "ember-cli-version-checker": "^1.1.4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Having it as a development dependency would result in `ember install` giving `Cannot find module 'ember-cli-version-checker'`.

```bash
$ ember install ember-anchor
version: 1.13.13
Installed packages for tooling via npm.
Cannot find module 'ember-cli-version-checker'
Error: Cannot find module 'ember-cli-version-checker'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:289:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (.../node_modules/ember-anchor/blueprints/ember-anchor/index.js:2:22)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:313:12)
    at Module.require (module.js:366:17)
```