### PR TITLE
Attempt to scroll only after render

### DIFF
--- a/addon/mixins/view-support.js
+++ b/addon/mixins/view-support.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { injectConfig } from './controller-support';
 
-const { computed: { oneWay } } = Ember;
+const { computed: { oneWay }, run } = Ember;
 
 export default Ember.Mixin.create({
   _anchorConfig: injectConfig(),
@@ -19,12 +19,12 @@ export default Ember.Mixin.create({
     if (!elem) {
       return;
     }
-    Ember.run.scheduleOnce('afterRender', this, this._scrollToElemPosition);
+    run.scheduleOnce('afterRender', this, this._scrollToElemPosition);
   },
 
   didInsertElement() {
     this._super(...arguments);
-    this._scrollToElemPosition();
+    run.scheduleOnce('afterRender', this, this._scrollToElemPosition);
   },
 
   _scrollToElemPosition() {


### PR DESCRIPTION
This way we can be sure the targeted elements are on page when we attempt to scroll to them.