### PR TITLE
fix: Add qp Value Instead of Overwrite

### DIFF
--- a/addon/mixins/controller-support.js
+++ b/addon/mixins/controller-support.js
@@ -16,7 +16,10 @@ export default Mixin.create({
 
   init() {
     let qpValue = this.get('anchorQueryParam');
-    this.queryParams = qpValue ? [qpValue] : [];
+    if (qpValue) {
+      if (!this.queryParams) this.queryParams = [];
+      this.queryParams.addObject(qpValue);
+    }
     this._super(...arguments);
   }
 });


### PR DESCRIPTION
This makes possible to have other qps alongside `anchorQueryParam`